### PR TITLE
change name of curl lib to libcurl

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -131,7 +131,7 @@ pub fn build(b: *std.Build) !void {
 
     const curl = b.addLibrary(.{
         .linkage = linkage,
-        .name = "curl",
+        .name = "libcurl",
         .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,


### PR DESCRIPTION
resolves the name conflict between the curl library and curl executable when importing their respective artifact in a downstream build.zig